### PR TITLE
Fixed bgComponent scrolling issue

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -94,7 +94,7 @@ body {
 
 /* BgComponent Styles */
 .bgCompWrapper {
-  position: absolute;
+  position: fixed;
   z-index: -99999;
 }
 


### PR DESCRIPTION
This pull request addresses the issue of the _BgComponent_ being scrollable. The wrapper's position has been changed from _absolute_ to _fixed_, ensuring that the _BgComponent_ remains in a fixed position on the viewport and does not scroll with the rest of the content.

Changes Made
Changed the **BgComponent** wrapper position from **absolute** to **fixed**.